### PR TITLE
feat: Adds theme provider

### DIFF
--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Section from './look';
 
-export default function Card({ className, color, text, children }) {
+export default function Card({ className, color, text, children, }) {
   return (
     <Section className={className} color={color} text={text}>
       {children}

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Section from './look';
 
-export default function Card({ className, color, text, children, }) {
+export default function Card({ className, color, text, children }) {
   return (
     <Section className={className} color={color} text={text}>
       {children}

--- a/src/components/Card/look.js
+++ b/src/components/Card/look.js
@@ -4,9 +4,9 @@ const Section = styled.section`
   padding: 2rem;
   max-width: 512px;
   margin: auto;
-  border: solid 1px ${({ color }) => color || '#fff'};
-  background: ${({ color }) => color || '#fff'};
-  color: ${({ text }) => text || '#000'};
+  border: solid 1px ${({ color, theme }) => color || theme.color };
+  background: ${({ color, theme }) => color || theme.color };
+  color: ${({ text, theme }) => text || theme.fontColor };
   white-space: pre-line;
 `;
 

--- a/src/components/Contact/look.js
+++ b/src/components/Contact/look.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const SocialLink = styled.a`
-  color: #333;
+  color: ${({ theme }) => theme.fontColor};
 
   &:hover {
     opacity: 0.7;

--- a/src/config.json
+++ b/src/config.json
@@ -126,5 +126,11 @@
       "color": "#0064a4",
       "text": "#fff"
     }
-  ]
+  ],
+  "theme": {
+    "color": "#fff",
+    "fontUrl": "https://fonts.googleapis.com/css?family=Montserrat",
+    "fontName": "'Montserrat', sans-serif",
+    "fontColor": "#000"
+  }
 }

--- a/src/containers/main/Main.js
+++ b/src/containers/main/Main.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { personalInfo, education, experiences } from 'config';
+import { ThemeProvider, withTheme } from 'styled-components';
+import { personalInfo, education, experiences, theme } from 'config';
 import BusinessCard from 'components/BusinessCard';
 import Education from 'components/EducationFactory';
 import Experiences from 'components/ExperiencesFactory';
@@ -7,17 +8,19 @@ import { Main, LeftSection, RightSection, FixedContent } from './sections';
 
 const MainPage = () => {
   return (
-    <Main>
-      <LeftSection>
-        <FixedContent>
-          <BusinessCard personalInfo={personalInfo} />
-          <Education education={education} />
-        </FixedContent>
-      </LeftSection>
-      <RightSection>
-        <Experiences experiences={experiences} />
-      </RightSection>
-    </Main>
+    <ThemeProvider theme={theme}>
+      <Main>
+        <LeftSection>
+          <FixedContent>
+            <BusinessCard personalInfo={personalInfo} />
+            <Education education={education} />
+          </FixedContent>
+        </LeftSection>
+        <RightSection>
+          <Experiences experiences={experiences} />
+        </RightSection>
+      </Main>
+    </ThemeProvider>
   );
 };
-export default MainPage;
+export default withTheme(MainPage);

--- a/src/containers/main/sections.js
+++ b/src/containers/main/sections.js
@@ -1,13 +1,15 @@
 import styled from 'styled-components';
 
 export const Main = styled.main`
-  @import url('https://fonts.googleapis.com/css?family=Montserrat');
-  font-family: 'Montserrat', sans-serif;
+  @import url('${({ theme }) => theme.fontUrl}');
+  font-family: ${({ theme }) => theme.fontName};
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: space-around;
   max-height: 100vh;
+  background-color: ${({ theme }) => theme.color };
+  
   overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
   z-index: 2;


### PR DESCRIPTION
This PR adds a theme provider to allow the customization of the fixed parts such as the `background-color`, `font-family` and `font-color`. I'll soon add support for the customization of each of the different font-sizes available. So far it is still hardcoded.

Users will now be able to tweak the config file passing their preferred styles as below:

```js
  "theme": {
    "color": "#333",
    "fontUrl": "https://fonts.googleapis.com/css?family=Roboto",
    "fontName": "'Roboto', sans-serif",
    "fontColor": "#FFF"
  }
```

![image](https://user-images.githubusercontent.com/10034981/53262645-efb35a80-36b5-11e9-944e-35dfb7e03bee.png)
